### PR TITLE
Logical and or

### DIFF
--- a/Parse.hs
+++ b/Parse.hs
@@ -84,11 +84,11 @@ expr =
     binOpChain = assignment
     assignment = chainr1 or (symbol "←" >> return Ast.Assign)
     or = chainl1 and binOp
-      where binOp = (symbol "||" >> return orToIf)
+      where binOp = (symbol "∨" >> return orToIf)
             orToIf :: Ast.Expr -> Ast.Expr -> Ast.Expr
             orToIf e1 e2 = Ast.If (e1) [e2] [Ast.TroolLit Ast.No]
     and = chainl1 equal binOp
-      where binOp = (symbol "&&" >> return andToIf)
+      where binOp = (symbol "∧" >> return andToIf)
             andToIf :: Ast.Expr -> Ast.Expr -> Ast.Expr
             andToIf e1 e2 = Ast.If (e1) [Ast.TroolLit Ast.Yes] [e2]
     equal = chainl1 notEqual (symbol "=" >> return Ast.Equal)

--- a/Parse.hs
+++ b/Parse.hs
@@ -97,13 +97,18 @@ expr =
     plusminus = chainl1 timesdivide binOp
       where binOp = (symbol "+" >> return Ast.Plus) <|>
                     (symbol "-" >> return Ast.Minus)
-    timesdivide = chainl1 and binOp
+    timesdivide = chainl1 or binOp
       where binOp = (symbol "*" >> return Ast.Times) <|>
                     (symbol "/" >> return Ast.Divide)
+    or = chainl1 and binOp
+      where binOp = (symbol "||" >> return orToIf)
+            orToIf :: Ast.Expr -> Ast.Expr -> Ast.Expr
+            orToIf e1 e2 = Ast.If (e1) [e2] [Ast.TroolLit Ast.No]
     and = chainl1 parseRealThing binOp
       where binOp = (symbol "&&" >> return andToIf)
             andToIf :: Ast.Expr -> Ast.Expr -> Ast.Expr
             andToIf e1 e2 = Ast.If (e1) [Ast.TroolLit Ast.Yes] [e2]
+
             parseRealThing =
                          try arrayIndex
                          <|> (parens expr)

--- a/Parse.hs
+++ b/Parse.hs
@@ -97,9 +97,13 @@ expr =
     plusminus = chainl1 timesdivide binOp
       where binOp = (symbol "+" >> return Ast.Plus) <|>
                     (symbol "-" >> return Ast.Minus)
-    timesdivide = chainl1 parseRealThing binOp
+    timesdivide = chainl1 and binOp
       where binOp = (symbol "*" >> return Ast.Times) <|>
                     (symbol "/" >> return Ast.Divide)
+    and = chainl1 parseRealThing binOp
+      where binOp = (symbol "&&" >> return andToIf)
+            andToIf :: Ast.Expr -> Ast.Expr -> Ast.Expr
+            andToIf e1 e2 = Ast.If (e1) [Ast.TroolLit Ast.Yes] [e2]
             parseRealThing =
                          try arrayIndex
                          <|> (parens expr)

--- a/pow.bnf
+++ b/pow.bnf
@@ -24,6 +24,7 @@ Expr       -> Expr '>=' Expr
 Expr       -> Expr '↔' Expr
 Expr       -> Expr '=' Expr
 Expr       -> Expr '≠' Expr
+Expr       -> Expr '&&' Expr
 Expr       -> Variable
 Expr       -> '⊥'
 Expr       -> '⊤'

--- a/pow.bnf
+++ b/pow.bnf
@@ -25,6 +25,7 @@ Expr       -> Expr '↔' Expr
 Expr       -> Expr '=' Expr
 Expr       -> Expr '≠' Expr
 Expr       -> Expr '&&' Expr
+Expr       -> Expr '||' Expr
 Expr       -> Variable
 Expr       -> '⊥'
 Expr       -> '⊤'

--- a/syntax.pow
+++ b/syntax.pow
@@ -2,11 +2,11 @@ static main⊂⊃ /
   ~true ← ⊤:
   ~false ← ⊥:
 
-  ¿ ~true && (✎ |should not happen|) ? /
+  ¿ ~true || (✎ |should happen|) ? /
     ✎ |works|:
   \
 
-  ¿ ~false && (✎ |should happen|) ? /
-    ✎ |works|:
+  ¿ ~false || (✎ |should not happen|) ? /
+    ✎ |WRONG!!|:
   \
 \

--- a/syntax.pow
+++ b/syntax.pow
@@ -2,11 +2,11 @@ static main⊂⊃ /
   ~true ← ⊤:
   ~false ← ⊥:
 
-  ¿ ~true || (✎ |should happen|) ? /
+  ¿ ~true ∨ (✎ |should happen|) ? /
     ✎ |works|:
   \
 
-  ¿ ~false || (✎ |should not happen|) ? /
+  ¿ ~false ∨ (✎ |should not happen|) ? /
     ✎ |WRONG!!|:
   \
 \

--- a/syntax.pow
+++ b/syntax.pow
@@ -1,67 +1,12 @@
-static add⊂~a, ~b⊃ /
-  ↜ ~a + ~b:
-\
-
 static main⊂⊃ /
-  ~foo ← 1:
-  ~bar ← |bar|:
-  ~two_foos ← ~foo * 2:
-  ~with_newline ← |Hello 'n' world|:
-  ~with_pipe ← ~with_newline ↔ |!!|:
+  ~true ← ⊤:
+  ~false ← ⊥:
 
-  ⊂1, 2⊃ ↝ add:
-  ⊂⊂1, 2⊃ ↝ add, 10⊃ ↝ add:
-  ✎ ⊂⊂1, 2⊃ ↝ add, 10⊃ ↝ add:
-
-  ¿ ~foo = ⊤ ? /
-    ~bar:
+  ¿ ~true && (✎ |should not happen|) ? /
+    ✎ |works|:
   \
 
-  ¿ ~foo ≠ ⊤ ? /
-    ~bar:
-  \ ! /
-    ~foo:
-    ✎ ⊂⊂1, 2⊃ ↝ add, 10⊃ ↝ add:
+  ¿ ~false && (✎ |should happen|) ? /
+    ✎ |works|:
   \
-
-  ~something_true ← ⊤:
-  ~something_false ← ⊥:
-  ¿ ⊤ ? /
-    ✎ |the true branch|:
-  \ ! /
-    ✎ |the else branch|:
-  \
-
-  ¿ 1 ? / 123: \
-
-  ¿ ~something_true ? /
-    ~bar:
-  \ ! /
-    ✎ |its false!|:
-  \
-
-  ~i ← 0:
-  ⟳ ~i < 10 ? /
-    ✎ |Looping again|:
-    ~i ← ~i + 1:
-  \
-
-  ~array ← #1,2,3:
-  5(~array):
-
-  ~something_maybe ← ⟛:
-
-  ~j ← 0:
-  ⟳ ~j < |hej| ? /
-    ¿ ~something_maybe ? /
-      ✎ |maybe was true|:
-    \ ! /
-      ✎ |maybe was false!|:
-    \
-    ~j ← ~j + 1:
-  \
-  ✎ #1,2,3,4,5:
-  ✎ 123:
-  ✎ #1,~a ← (#2,3,4),(#~a, ~a):
-  ✎ #1,~a ← 2,~a:
 \


### PR DESCRIPTION
Tilføjer to nye infix operatorer til grammatikken:
- `Expr ∧ Expr`: Logisk og. Venstre associativ og binder stærkere end eller.
- `Expr ∨ Expr`: Logisk eller. Også venstre associativ.

Precedence er såleders

```
1 + 2 = 3 ∧ ⊥ ∨ ~a = 1 ∧ ~foo
{{ samme som }}
((1 + 2 = 3) ∧ ⊥) ∨ ((~a = 1) ∧ ~foo)
```

Begger er short circuiting og bliver blot parsed til if statements, så det krævede ingen ændringer i fortolkeren.
